### PR TITLE
haccmds: drop ${COREBASE}/LICENSE references

### DIFF
--- a/recipes-hac/haccmds/haccmds_1.0.bb
+++ b/recipes-hac/haccmds/haccmds_1.0.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Helix App Cloud Command Line Support"
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690 \
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302 \
                     file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 
 


### PR DESCRIPTION
The top level LICENSE file is not actually a license, it refers
other licenses that are used by Bitbake and Meta-data. Relying
on this file could cause problems for recipes when this file
changes, which it is about to.

Signed-off-by: Ming Liu <ming.liu@windriver.com>